### PR TITLE
Allow players to designate servers as civ servers

### DIFF
--- a/common/src/main/java/sh/okx/civmodern/common/CivServer.java
+++ b/common/src/main/java/sh/okx/civmodern/common/CivServer.java
@@ -1,0 +1,42 @@
+package sh.okx.civmodern.common;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class CivServer {
+    public static final String IS_CIV_SERVER_KEY = "civ";
+
+    public interface ServerData {
+        boolean isCivServer();
+
+        void isCivServer(
+            boolean isCivServer
+        );
+    }
+
+    public static @Nullable Boolean isCivServer() {
+        if (Minecraft.getInstance().getCurrentServer() instanceof final ServerData serverData) {
+            return serverData.isCivServer();
+        }
+        return null;
+    }
+
+    public static @NotNull Checkbox createCheckbox(
+        final int x,
+        final int y,
+        final @NotNull Font font,
+        final @NotNull ServerData serverData
+    ) {
+        return Checkbox.builder(Component.literal("Civ?"), font)
+            .pos(x, y)
+            .tooltip(Tooltip.create(Component.translatable("civmodern.gui.tooltip.civ.is")))
+            .onValueChange((checkbox, value) -> serverData.isCivServer(value))
+            .selected(serverData.isCivServer())
+            .build();
+    }
+}

--- a/common/src/main/java/sh/okx/civmodern/common/macro/AttackMacro.java
+++ b/common/src/main/java/sh/okx/civmodern/common/macro/AttackMacro.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import sh.okx.civmodern.common.AbstractCivModernMod;
 import sh.okx.civmodern.common.events.ClientTickEvent;
 import sh.okx.civmodern.common.events.ScrollEvent;
-import sh.okx.civmodern.common.mixins.KeyMappingAccessor;
+import sh.okx.civmodern.common.mixins.accessors.KeyMappingAccessor;
 
 public class AttackMacro {
 

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/accessors/KeyMappingAccessor.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/accessors/KeyMappingAccessor.java
@@ -1,4 +1,4 @@
-package sh.okx.civmodern.common.mixins;
+package sh.okx.civmodern.common.mixins.accessors;
 
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
@@ -6,9 +6,11 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(KeyMapping.class)
 public interface KeyMappingAccessor {
-    @Accessor
+    @Accessor("clickCount")
     int getClickCount();
 
     @Accessor("clickCount")
-    void setClickCount(int clickCount);
+    void setClickCount(
+        int clickCount
+    );
 }

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/accessors/ScreenAccessor.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/accessors/ScreenAccessor.java
@@ -1,0 +1,25 @@
+package sh.okx.civmodern.common.mixins.accessors;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.screens.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Screen.class)
+public interface ScreenAccessor {
+    @Accessor("minecraft")
+    Minecraft cm_accessor$getMinecraft();
+
+    @Accessor("font")
+    Font cm_accessor$getFont();
+
+    @Invoker("addRenderableWidget")
+    <T extends GuiEventListener & Renderable & NarratableEntry> T cm_invoker$addRenderableWidget(
+        T guiEventListener
+    );
+}

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/DirectJoinServerScreenMixin.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/DirectJoinServerScreenMixin.java
@@ -1,0 +1,39 @@
+package sh.okx.civmodern.common.mixins.serverdata;
+
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.DirectJoinServerScreen;
+import net.minecraft.client.multiplayer.ServerData;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import sh.okx.civmodern.common.CivServer;
+import sh.okx.civmodern.common.mixins.accessors.ScreenAccessor;
+
+@Mixin(DirectJoinServerScreen.class)
+public abstract class DirectJoinServerScreenMixin implements ScreenAccessor {
+    @Final
+    @Shadow
+    private ServerData serverData;
+
+    @Shadow
+    private EditBox ipEdit;
+
+    @Inject(
+        method = "init",
+        at = @At("TAIL")
+    )
+    private void cm_inject$init(
+        final @NotNull CallbackInfo ci
+    ) {
+        cm_invoker$addRenderableWidget(CivServer.createCheckbox(
+            this.ipEdit.getX() + this.ipEdit.getWidth() + 4,
+            this.ipEdit.getY() + 1,
+            cm_accessor$getFont(),
+            (CivServer.ServerData) this.serverData
+        ));
+    }
+}

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/EditServerScreenMixin.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/EditServerScreenMixin.java
@@ -1,0 +1,39 @@
+package sh.okx.civmodern.common.mixins.serverdata;
+
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.EditServerScreen;
+import net.minecraft.client.multiplayer.ServerData;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import sh.okx.civmodern.common.CivServer;
+import sh.okx.civmodern.common.mixins.accessors.ScreenAccessor;
+
+@Mixin(EditServerScreen.class)
+public abstract class EditServerScreenMixin implements ScreenAccessor {
+    @Shadow
+    private EditBox nameEdit;
+
+    @Final
+    @Shadow
+    private ServerData serverData;
+
+    @Inject(
+        method = "init",
+        at = @At("TAIL")
+    )
+    private void cm_inject$init(
+        final @NotNull CallbackInfo ci
+    ) {
+        cm_invoker$addRenderableWidget(CivServer.createCheckbox(
+            this.nameEdit.getX() + this.nameEdit.getWidth() + 4,
+            this.nameEdit.getY() + 1,
+            cm_accessor$getFont(),
+            (CivServer.ServerData) this.serverData
+        ));
+    }
+}

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/ServerDataMixin.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/serverdata/ServerDataMixin.java
@@ -1,0 +1,75 @@
+package sh.okx.civmodern.common.mixins.serverdata;
+
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import sh.okx.civmodern.common.CivServer;
+
+@Mixin(ServerData.class)
+public abstract class ServerDataMixin implements CivServer.ServerData {
+    @Unique
+    private boolean _cm$isCivServer;
+
+    @Unique
+    @Override
+    public boolean isCivServer() {
+        return this._cm$isCivServer;
+    }
+
+    @Unique
+    @Override
+    public void isCivServer(
+        final boolean isCivServer
+    ) {
+        this._cm$isCivServer = isCivServer;
+    }
+
+    @Inject(
+        method = "copyFrom",
+        at = @At("TAIL")
+    )
+    private void cm_inject$copyFrom(
+        final @NotNull ServerData serverData,
+        final @NotNull CallbackInfo ci
+    ) {
+        this._cm$isCivServer = ((CivServer.ServerData) serverData).isCivServer();
+    }
+
+    @Inject(
+        method = "write",
+        at = @At(
+            value = "RETURN",
+            shift = At.Shift.BEFORE
+        ),
+        locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void cm_inject$write(
+        final @NotNull CallbackInfoReturnable<CompoundTag> cir,
+        final @NotNull CompoundTag tag
+    ) {
+        tag.putBoolean(CivServer.IS_CIV_SERVER_KEY, isCivServer());
+    }
+
+    @Inject(
+        method = "read",
+        at = @At(
+            value = "RETURN",
+            shift = At.Shift.BEFORE
+        ),
+        locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private static void cm_inject$read(
+        final @NotNull CompoundTag compoundTag,
+        final @NotNull CallbackInfoReturnable<ServerData> cir,
+        final @NotNull ServerData serverData
+    ) {
+        ((ServerDataMixin) (Object) serverData).isCivServer(compoundTag.getBoolean(CivServer.IS_CIV_SERVER_KEY));
+    }
+}

--- a/common/src/main/java/sh/okx/civmodern/common/radar/Radar.java
+++ b/common/src/main/java/sh/okx/civmodern/common/radar/Radar.java
@@ -47,6 +47,7 @@ import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 import sh.okx.civmodern.common.CivMapConfig;
+import sh.okx.civmodern.common.CivServer;
 import sh.okx.civmodern.common.ColourProvider;
 import sh.okx.civmodern.common.events.ClientTickEvent;
 import sh.okx.civmodern.common.events.EventBus;
@@ -58,18 +59,6 @@ import java.util.*;
 import static org.lwjgl.opengl.GL11.*;
 
 public class Radar {
-
-    private static boolean hideY;
-
-    static {
-        URL resource = Radar.class.getResource("/civmc");
-        if (resource != null) {
-            hideY = true;
-        } else {
-            hideY = false;
-        }
-    }
-
     private final EventBus eventBus;
     private final ColourProvider colourProvider;
     private final CivMapConfig config;
@@ -99,7 +88,7 @@ public class Radar {
     }
 
     private boolean hideY() {
-        return hideY;
+        return CivServer.isCivServer() == Boolean.TRUE;
     }
 
     @Subscribe

--- a/common/src/main/resources/assets/civmodern/lang/en_us.json
+++ b/common/src/main/resources/assets/civmodern/lang/en_us.json
@@ -37,5 +37,6 @@
     "civmodern.screen.ice.stop.disable": "Stop on low food: Disabled",
     "civmodern.radar.enter" : "§r%s §eappeared at §b[%s§b]",
     "civmodern.radar.hover" : "Click to highlight position\nControl click to add waypoint",
-    "civmodern.radar.leave" : "§r%s §edisappeared at §b[%s§b]"
+    "civmodern.radar.leave" : "§r%s §edisappeared at §b[%s§b]",
+    "civmodern.gui.tooltip.civ.is": "Is this a civ server?"
 }

--- a/common/src/main/resources/civmodern.mixins.json
+++ b/common/src/main/resources/civmodern.mixins.json
@@ -5,9 +5,15 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-        "InventoryMixin",
-        "KeyMappingAccessor",
-        "DecorationsGuiGraphicsMixin"
+        "accessors.KeyMappingAccessor",
+        "accessors.ScreenAccessor",
+
+        "serverdata.DirectJoinServerScreenMixin",
+        "serverdata.EditServerScreenMixin",
+        "serverdata.ServerDataMixin",
+
+        "DecorationsGuiGraphicsMixin",
+        "InventoryMixin"
     ],
     "server": [],
     "injectors": {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -75,16 +75,6 @@ publishing {
     }
 }
 
-import net.fabricmc.loom.task.RemapJarTask
-
-tasks.register("remapCivMc", RemapJarTask) {
-    inputFile.set shadowJar.archiveFile
-    dependsOn shadowJar
-    archiveClassifier = "civmc-fabric"
-    from sourceSets.main.output
-    from "../civmc"
-}
-
 tasks.register("cleanJar", Delete) {
     delete fileTree("../dist") {
         include "*-fabric.jar"
@@ -93,7 +83,7 @@ tasks.register("cleanJar", Delete) {
 
 tasks.register("copyJar", Copy) {
     dependsOn cleanJar
-    from remapJar, remapCivMc
+    from remapJar
     into "../dist"
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -82,16 +82,6 @@ publishing {
     }
 }
 
-import net.fabricmc.loom.task.RemapJarTask
-
-tasks.register("remapCivMc", RemapJarTask) {
-    inputFile.set shadowJar.archiveFile
-    dependsOn shadowJar
-    archiveClassifier = "civmc-forge"
-    from sourceSets.main.output
-    from "../civmc"
-}
-
 tasks.register("cleanJar", Delete) {
     delete fileTree("../dist") {
         include "*-forge.jar"
@@ -100,7 +90,7 @@ tasks.register("cleanJar", Delete) {
 
 tasks.register("copyJar", Copy) {
     dependsOn cleanJar
-    from remapJar, remapCivMc
+    from remapJar
     into "../dist"
 }
 


### PR DESCRIPTION
This allows players to designate a server as a civ-server with the Edit Server and Direct Connection screen, and it'll be persistently saved within the user's `servers.dat` file. This way, players cannot finagle their settings to turn off certain restrictions without disconnecting from the server, but also means that those restrictions can be tied to this marker, rather than having a separately compiled version of the mod for civ.