### PR TITLE
Add layered Parchment mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,10 @@ subprojects {
 
     dependencies {
         minecraft("com.mojang:minecraft:${rootProject.minecraft_version}")
-        mappings(loom.officialMojangMappings())
+        mappings(loom.layered() {
+            officialMojangMappings()
+            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:${rootProject.parchment_version}@zip")
+        })
     }
 }
 
@@ -33,11 +36,10 @@ allprojects {
     group = rootProject.maven_group
 
     repositories {
-        // Add repositories to retrieve artifacts from in here.
-        // You should only use this when depending on other mods because
-        // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-        // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-        // for more information about repositories.
+        maven {
+            name = "ParchmentMC"
+            url = "https://maven.parchmentmc.org"
+        }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,8 @@ mod_issues_url=https://github.com/okx-code/civmodern/issues
 
 minecraft_version=1.20.4
 architectury_version=11.1.13
+# https://parchmentmc.org/docs/getting-started
+parchment_version=2024.04.14
 enabled_platforms=fabric,forge
 
 # https://fabricmc.net/versions.html


### PR DESCRIPTION
This adds Parchment's mappings on top of the official Mojang mappings. It's not strictly necessary but helps at lot when working with NMS classes, particularly with parameter names. Got this idea from [CombatRadar](https://github.com/MrJeremyFisher/CombatRadar/blob/bafac1f3a2b88843e791af3c2b07e5d45b9f8a43/build.gradle#L21).