### PR TITLE
Fixup compacted item mixins

### DIFF
--- a/common/src/main/java/sh/okx/civmodern/common/mixins/GuiGraphicsMixin.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/GuiGraphicsMixin.java
@@ -1,7 +1,5 @@
 package sh.okx.civmodern.common.mixins;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -10,7 +8,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import sh.okx.civmodern.common.AbstractCivModernMod;
 import sh.okx.civmodern.common.features.ExtendedItemStack;
 
@@ -19,30 +17,28 @@ public abstract class GuiGraphicsMixin {
     @Unique
     private boolean civmodern$isCompactedItem = false;
 
-    @ModifyVariable(
+    @Redirect(
         method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/mojang/blaze3d/vertex/PoseStack;pushPose()V",
-            shift = At.Shift.BEFORE
-        ),
-        argsOnly = true
+            target = "Lnet/minecraft/world/item/ItemStack;getCount()I",
+            ordinal = 0
+        )
     )
-    public @NotNull ItemStack civmodern$alwaysShowItemAmountIfCompacted(
-        final @NotNull ItemStack stack,
-        final @Local(argsOnly = true) LocalRef<String> text
+    protected int civmodern$alwaysShowItemAmountIfCompacted(
+        final @NotNull ItemStack stack
     ) {
         if (this.civmodern$isCompactedItem = ((ExtendedItemStack) (Object) stack).isMarkedAsCompacted()) {
-            text.set(Integer.toString(stack.getCount()));
+            return 0; // Will force the real count to be displayed since it's a !=1 check
         }
-        return stack;
+        return stack.getCount();
     }
 
     @ModifyConstant(
         method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
         constant = @Constant(intValue = 16777215)
     )
-    public int civmodern$colourItemDecorationIfCompacted(
+    protected int civmodern$colourItemDecorationIfCompacted(
         final int decorationColour
     ) {
         if (this.civmodern$isCompactedItem) {

--- a/common/src/main/java/sh/okx/civmodern/common/mixins/ItemStackMixin.java
+++ b/common/src/main/java/sh/okx/civmodern/common/mixins/ItemStackMixin.java
@@ -1,19 +1,21 @@
 package sh.okx.civmodern.common.mixins;
 
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemLore;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import sh.okx.civmodern.common.features.ExtendedItemStack;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin implements ExtendedItemStack {
+    @Shadow
+    public abstract DataComponentMap getComponents();
+
     @Unique
     private Boolean civmodern$isCompacted = null;
 
@@ -28,12 +30,11 @@ public abstract class ItemStackMixin implements ExtendedItemStack {
 
     @Unique
     private boolean civmodern$isCompacted() {
-        ItemLore lore = ((ItemStack) (Object) this).getComponents().get(DataComponents.LORE);
-        Component name = ((ItemStack) (Object) this).getComponents().get(DataComponents.ITEM_NAME);
-        if (lore == null || name == null) {
+        final ItemLore lore = getComponents().get(DataComponents.LORE);
+        if (lore == null) {
             return false;
         }
-        for (Component line : lore.lines()) {
+        for (final Component line : lore.lines()) {
             if (line == null) {
                 continue;
             }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -26,10 +26,6 @@ dependencies {
 
     common(project(path: ":common", configuration: "namedElements")) { transitive = false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
-
-    // Forge doesn't include extras by default
-    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.6"))
-    implementation(include("io.github.llamalad7:mixinextras-forge:0.3.6"))
 }
 
 processResources {


### PR DESCRIPTION
Also switches from a MixinExtras local capture to a simple redirect, which means the Forge dependency is no longer necessary.