### PR TITLE
Bump to 1.21.4 and rewrite small portions of the rendering logic in Radar.java

### DIFF
--- a/common/src/main/java/sh/okx/civmodern/common/radar/Radar.java
+++ b/common/src/main/java/sh/okx/civmodern/common/radar/Radar.java
@@ -19,9 +19,7 @@ import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.player.RemotePlayer;
 import net.minecraft.client.renderer.CoreShaders;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -299,22 +297,17 @@ public class Radar {
         } else {
             guiGraphics.pose().mulPose(Axis.ZP.rotationDegrees(player.getViewYRot(delta)));
         }
-        BakedModel bakedModel = Minecraft.getInstance().getItemRenderer().getModel(item, player.level(), player, 0);
+        ClientLevel world = Minecraft.getInstance().level;
         guiGraphics.pose().translate(0, 0, blit);
         guiGraphics.pose().scale(config.getIconSize(), config.getIconSize(), 1);
         guiGraphics.pose().mulPose(new Matrix4f().scaling(1.0f, -1.0f, 1.0f));
         guiGraphics.pose().scale(16.0f, 16.0f, 16.0f);
 
-        boolean notUseBlockLight = !bakedModel.usesBlockLight();
-        if (notUseBlockLight) {
-            Lighting.setupForFlatItems();
-        }
+        Lighting.setupForFlatItems();
         guiGraphics.drawSpecial(source ->
-            Minecraft.getInstance().getItemRenderer().render(item, ItemDisplayContext.GUI, false, guiGraphics.pose(), source, 0xF000F0, OverlayTexture.NO_OVERLAY, bakedModel));
+            Minecraft.getInstance().getItemRenderer().renderStatic(player, item, ItemDisplayContext.GUI, false, guiGraphics.pose(), source, world, 0xF000F0, OverlayTexture.NO_OVERLAY, 0));
         guiGraphics.flush();
-        if (notUseBlockLight) {
-            Lighting.setupFor3DItems();
-        }
+        Lighting.setupFor3DItems();
 
         guiGraphics.pose().popPose();
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3072M
 
 archives_base_name=civmodern
 maven_group=sh.okx.civmodern
-mod_version=1.7.1
+mod_version=1.7.2
 mod_name=CivModern
 mod_description=Radar and civ utilities
 mod_authors=Okx,Protonull
@@ -11,10 +11,10 @@ mod_home_url=https://github.com/okx-code/civmodern
 mod_source_url=https://github.com/okx-code/civmodern
 mod_issues_url=https://github.com/okx-code/civmodern/issues
 
-minecraft_version=1.21.3
+minecraft_version=1.21.4
 architectury_version=11.1.13
 enabled_platforms=fabric,forge
 
 # https://fabricmc.net/versions.html
 fabric_loader_version=0.16.10
-fabric_api_version=0.114.0+1.21.3
+fabric_api_version=0.119.3+1.21.4


### PR DESCRIPTION
Mojang seems to have made changes to the rendering API in 1.21.4, so I went ahead and rewrite small portions of Radar.java code to replace .render with .renderStatic (essentially same thing but without needing bakedModel, at least in my testing). I removed bakedModel because it is not needed anymore, as the items and players in radar can display proper lighting without using bakedModel in this version.

I'm not sure if you are rewriting the whole of the rendering logic. If you are, please consider this a temporary fix so people can still use CivModern in 1.21.4.