### PR TITLE
repair costs on all items above base

### DIFF
--- a/src/main/java/sh/okx/civmodern/common/mixins/ItemRepairMixin.java
+++ b/src/main/java/sh/okx/civmodern/common/mixins/ItemRepairMixin.java
@@ -15,11 +15,9 @@ public abstract class ItemRepairMixin {
     @ModifyReturnValue(at = @At("RETURN"), method = "getTooltipLines")
     protected List<Component> handle(List<Component> original) {
         ItemStack itemStack = (ItemStack) (Object) this;
-        if (AbstractCivModernMod.getInstance().getConfig().isShowRepairCost() && itemStack.get(DataComponents.REPAIRABLE) != null) {
-            Integer repairCost = itemStack.get(DataComponents.REPAIR_COST);
-            if (repairCost != null) {
-                original.add(1, Component.translatable("civmodern.repaircost", repairCost + 2).withColor(0x379fa3));
-            }
+        Integer repairCost = itemStack.get(DataComponents.REPAIR_COST);
+        if (AbstractCivModernMod.getInstance().getConfig().isShowRepairCost() && repairCost != null && repairCost != 0) {
+            original.add(1, Component.translatable("civmodern.repaircost", repairCost + 2).withColor(0x379fa3));
         }
         return original;
     }


### PR DESCRIPTION
The existing implementation of repair cost text has one major flaw: It does not apply to all items the user would want it to apply to (bows). This is because REPAIRABLE refers to whether an item can be repaired using materials, which these items cannot. There is no property that neatly fits our needs, the closest would be ENCHANTABLE which also includes plain books.

This solution proposes that instead of having too many or too few items caught, and instead of an explicit list of items, we should instead apply this to every item, but only those that have a repair cost higher than base. In this way, all the items we care about will be caught (because all the items we care about are ones that reach a higher than base cost), and those we don't care about (which will never have a different repair cost) will be ignored.

The disadvantage is that we won't see a tooltip for any items at base repair cost, which is perhaps not perfect, but should not impede the user who will immediately cotton on to why this is the case.

To get the best of both worlds, it appears to be necessary to get explicit about which items we care about, which does not seem ideal, especially where new items are added to the game which we wish to be included.